### PR TITLE
Add support for labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,33 +12,36 @@ The variables that can be passed to this role and a brief description about them
 
     # License key
     newrelic_license_key: ab2fa361cd4d0d373833cad619d7bcc424d27c16
-    
+
     # Log level (error, warning, info, verbose, debug, verbosedebug)
     newrelic_loglevel: info
-    
+
     # Log file location
     newrelic_logfile: /var/log/newrelic/nrsysmond.log
-    
+
     # Proxy server. Default False
     newrelic_proxy: fred:secret@proxy.mydomain.com:8181
-    
+
     # Use SSL for all communication. Default False
     newrelic_ssl: "true"
-    
+
     # SSL CA Bundle path. Default False
     newrelic_ssl_ca_bundle: /etc/pki/tls/certs/ca-bundle.crt
-    
+
     # SSL CA Path. Default False
     newrelic_ssl_ca_path: /etc/ssl/certs
-    
+
     # Pid file locaiton
     newrelic_pidfile: /var/run/newrelic/nrsysmond.pid
-    
+
     # Collector hostname
     newrelic_collector_host: collector.newrelic.com
-    
+
     # Connection timeout for collector host
     newrelic_timeout: 30
+
+    # Labels
+    newrelic_labels: ['environment:production']
 
 ## Examples
 

--- a/templates/nrsysmond.cfg.j2
+++ b/templates/nrsysmond.cfg.j2
@@ -133,3 +133,15 @@ collector_host={{ newrelic_collector_host }}
 # Default: 30
 #
 timeout={{ newrelic_timeout }}
+
+#
+# Option : labels
+# Value  : A dictionary of colon-separated label names and values for categories
+#          that will be applied to the data sent from this agent.
+# Default: none
+#
+{% if newrelic_labels is defined %}
+labels={{ newrelic_labels|join(';') }};
+{% else %}
+#labels=
+{% endif %}


### PR DESCRIPTION
Hey,

This small PR enables asigning `labels` to your servers in NewRelic.
Usage example is included in README.