### PR TITLE
Add optional option to set the hostname of the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ The variables that can be passed to this role and a brief description about them
     
     # Connection timeout for collector host
     newrelic_timeout: 30
+    
+    # Sets the hostname of the server as it appears in New Relic. Default to OS-level hostname.
+    newrelic_hostname: "Foo Server"
 
 ## Examples
 

--- a/templates/nrsysmond.cfg.j2
+++ b/templates/nrsysmond.cfg.j2
@@ -133,3 +133,13 @@ collector_host={{ newrelic_collector_host }}
 # Default: 30
 #
 timeout={{ newrelic_timeout }}
+
+#
+# Option : hostname
+# Value  : Sets the hostname of the server as it appears in New Relic. The
+#          server agent does not support spaces, and special characters besides
+#          hyphens -, underscores _, and periods . are discouraged. The name is
+#          restricted to 64 characters. For more information, see
+#          https://docs.newrelic.com/docs/servers/new-relic-servers-linux/maintenance/changing-linux-server-name
+# Default: None (OS-level hostname)
+hostname="{{ newrelic_hostname | default('') }}"


### PR DESCRIPTION
Add optional option to set the hostname of the server as it appears in New Relic.