### PR TITLE
Add labels configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ The variables that can be passed to this role and a brief description about them
     
     # Connection timeout for collector host
     newrelic_timeout: 30
+    
+    # Add labels to the host (key:value - defaults to empty)
+    newrelic_labels: "Tag:webserver;Tier:production;App:frontend"
 
 ## Examples
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,4 @@ newrelic_ssl_ca_path: False
 newrelic_pidfile: /var/run/newrelic/nrsysmond.pid
 newrelic_collector_host: collector.newrelic.com
 newrelic_timeout: 30
+newrelic_labels: ""

--- a/templates/nrsysmond.cfg.j2
+++ b/templates/nrsysmond.cfg.j2
@@ -133,3 +133,13 @@ collector_host={{ newrelic_collector_host }}
 # Default: 30
 #
 timeout={{ newrelic_timeout }}
+
+#
+# Option : labels
+# Value  : A dictionary of label names and values for categories that will be 
+#          applied to the data sent from this agent. This may also be expressed 
+#          as a semicolon delimited string of colon-separated pairs. For example: 
+#          labels=Server:One;Data Center:Primary;.
+# Default: ""
+#
+labels={{ newrelic_labels }}


### PR DESCRIPTION
Add the ability to set labels for the host in the configuration file.