### PR TITLE
Add Python Agent Support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 newrelic_loglevel: info
-newrelic_logfile: /var/log/newrelic/nrsysmond.log
+newrelic_log_location: /var/log/newrelic
+newrelic_logfile: "{{ newrelic_log_location }}/nrsysmond.log"
 newrelic_proxy: False
 newrelic_ssl: "false"
 newrelic_ssl_ca_bundle: False
@@ -8,3 +9,10 @@ newrelic_ssl_ca_path: False
 newrelic_pidfile: /var/run/newrelic/nrsysmond.pid
 newrelic_collector_host: collector.newrelic.com
 newrelic_timeout: 30
+
+# newrelic python agent
+newrelic_python_agent: false
+newrelic_python_agent_app_name: ''
+newrelic_monitor_mode: true
+newrelic_python_logfile: "{{ newrelic_log_location }}/newrelic-python-agent.log"
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,3 +29,12 @@
     name: newrelic-sysmond
     state: started
     enabled: yes
+
+- name: Render Newrelic Python Agent Configuration
+  template:
+    src: newrelic.ini.j2
+    dest: /etc/newrelic/newrelic.ini
+    group: newrelic
+    owner: root
+    mode: 0640
+  when: newrelic_python_agent

--- a/templates/newrelic.ini.j2
+++ b/templates/newrelic.ini.j2
@@ -1,0 +1,192 @@
+# ---------------------------------------------------------------------------
+
+#
+# This file configures the New Relic Python Agent.
+#
+# The path to the configuration file should be supplied to the function
+# newrelic.agent.initialize() when the agent is being initialized.
+#
+# The configuration file follows a structure similar to what you would
+# find for Microsoft Windows INI files. For further information on the
+# configuration file format see the Python ConfigParser documentation at:
+#
+#    http://docs.python.org/library/configparser.html
+#
+# For further discussion on the behaviour of the Python agent that can
+# be configured via this configuration file see:
+#
+#    http://newrelic.com/docs/python/python-agent-configuration
+#
+
+# ---------------------------------------------------------------------------
+
+# Here are the settings that are common to all environments.
+
+[newrelic]
+
+# You must specify the license key associated with your New
+# Relic account. This key binds the Python Agent's data to your
+# account in the New Relic service.
+license_key = {{ license_key }}
+
+# The appplication name. Set this to be the name of your
+# application as you would like it to show up in New Relic UI.
+# The UI will then auto-map instances of your application into a
+# entry on your home dashboard page.
+app_name = {{ newrelic_python_app_name }}
+
+# When "true", the agent collects performance data about your
+# application and reports this data to the New Relic UI at
+# newrelic.com. This global switch is normally overridden for
+# each environment below.
+monitor_mode = {{ monitor_mode }}
+
+# Sets the name of a file to log agent messages to. Useful for
+# debugging any issues with the agent. This is not set by
+# default as it is not known in advance what user your web
+# application processes will run as and where they have
+# permission to write to. Whatever you set this to you must
+# ensure that the permissions for the containing directory and
+# the file itself are correct, and that the user that your web
+# application runs as can write to the file. If not able to
+# write out a log file, it is also possible to say "stderr" and
+# output to standard error output. This would normally result in
+# output appearing in your web server log.
+log_file = {{ log_location }}
+
+# Sets the level of detail of messages sent to the log file, if
+# a log file location has been provided. Possible values, in
+# increasing order of detail, are: "critical", "error", "warning",
+# "info" and "debug". When reporting any agent issues to New
+# Relic technical support, the most useful setting for the
+# support engineers is "debug". However, this can generate a lot
+# of information very quickly, so it is best not to keep the
+# agent at this level for longer than it takes to reproduce the
+# problem you are experiencing.
+log_level = {{ log_level }}
+
+# The Python Agent communicates with the New Relic service using
+# HTTP by default. If you want to communicate via HTTPS to
+# increase security, then turn on SSL by setting this value to
+# true. Note, this will result in increased CPU overhead to
+# perform the encryption involved in SSL communication, but this
+# work is done asynchronously to the threads that process your
+# application code, so it should not impact response times.
+ssl = {{ ssl }}
+
+# The Python Agent will attempt to connect directly to the New
+# Relic service. If there is an intermediate firewall between
+# your host and the New Relic service that requires you to use a
+# HTTP proxy, then you should set both the "proxy_host" and
+# "proxy_port" settings to the required values for the HTTP
+# proxy. The "proxy_user" and "proxy_pass" settings should
+# additionally be set if proxy authentication is implemented by
+# the HTTP proxy.
+# proxy_host = hostname
+# proxy_port = 8080
+# proxy_user =
+# proxy_pass =
+
+# Tells the transaction tracer and error collector (when
+# enabled) whether or not to capture the query string for the
+# URL and send it as the request parameters for display in the
+# UI. When "true", it is still possible to exclude specific
+# values from being captured using the "ignored_params" setting.
+capture_params = false
+
+# Space separated list of variables that should be removed from
+# the query string captured for display as the request
+# parameters in the UI.
+ignored_params =
+
+# The transaction tracer captures deep information about slow
+# transactions and sends this to the UI on a periodic basis. The
+# transaction tracer is enabled by default. Set this to "false"
+# to turn it off.
+transaction_tracer.enabled = {{ transaction_trace }}
+
+# Threshold in seconds for when to collect a transaction trace.
+# When the response time of a controller action exceeds this
+# threshold, a transaction trace will be recorded and sent to
+# the UI. Valid values are any positive float value, or (default)
+# "apdex_f", which will use the threshold for a dissatisfying
+# Apdex controller action - four times the Apdex T value.
+transaction_tracer.transaction_threshold = apdex_f
+
+# When the transaction tracer is on, SQL statements can
+# optionally be recorded. The recorder has three modes, "off"
+# which sends no SQL, "raw" which sends the SQL statement in its
+# original form, and "obfuscated", which strips out numeric and
+# string literals.
+transaction_tracer.record_sql = obfuscated
+
+# Threshold in seconds for when to collect stack trace for a SQL
+# call. In other words, when SQL statements exceed this
+# threshold, then capture and send to the UI the current stack
+# trace. This is helpful for pinpointing where long SQL calls
+# originate from in an application.
+transaction_tracer.stack_trace_threshold = 0.5
+
+# Determines whether the agent will capture query plans for slow
+# SQL queries. Only supported in MySQL and PostgreSQL. Set this
+# to "false" to turn it off.
+transaction_tracer.explain_enabled = true
+
+# Threshold for query execution time below which query plans
+# will not not be captured. Relevant only when "explain_enabled"
+# is true.
+transaction_tracer.explain_threshold = 0.5
+
+# Space separated list of function or method names in form
+# 'module:function' or 'module:class.function' for which
+# additional function timing instrumentation will be added.
+transaction_tracer.function_trace =
+
+# The error collector captures information about uncaught
+# exceptions or logged exceptions and sends them to UI for
+# viewing. The error collector is enabled by default. Set this
+# to "false" to turn it off.
+error_collector.enabled = true
+
+# To stop specific errors from reporting to the UI, set this to
+# a space separated list of the Python exception type names to
+# ignore. The exception name should be of the form 'module:class'.
+error_collector.ignore_errors =
+
+# Browser monitoring is the Real User Monitoring feature of the UI.
+# For those Python web frameworks that are supported, this
+# setting enables the auto-insertion of the browser monitoring
+# JavaScript fragments.
+browser_monitoring.auto_instrument = true
+
+# A thread profiling session can be scheduled via the UI when
+# this option is enabled. The thread profiler will periodically
+# capture a snapshot of the call stack for each active thread in
+# the application to construct a statistically representative
+# call tree.
+thread_profiler.enabled = true
+
+# ---------------------------------------------------------------------------
+
+#
+# The application environments. These are specific settings which
+# override the common environment settings. The settings related to a
+# specific environment will be used when the environment argument to the
+# newrelic.agent.initialize() function has been defined to be either
+# "development", "test", "staging" or "production".
+#
+
+[newrelic:development]
+monitor_mode = false
+
+[newrelic:test]
+monitor_mode = false
+
+[newrelic:staging]
+app_name = {{ app_name }} (Staging)
+monitor_mode = true
+
+[newrelic:production]
+monitor_mode = true
+
+# ---------------------------------------------------------------------------

--- a/templates/newrelic.ini.j2
+++ b/templates/newrelic.ini.j2
@@ -27,19 +27,19 @@
 # You must specify the license key associated with your New
 # Relic account. This key binds the Python Agent's data to your
 # account in the New Relic service.
-license_key = {{ license_key }}
+license_key = {{ newrelic_license_key }}
 
 # The appplication name. Set this to be the name of your
 # application as you would like it to show up in New Relic UI.
 # The UI will then auto-map instances of your application into a
 # entry on your home dashboard page.
-app_name = {{ newrelic_python_app_name }}
+app_name = {{ newrelic_python_agent_app_name }}
 
 # When "true", the agent collects performance data about your
 # application and reports this data to the New Relic UI at
 # newrelic.com. This global switch is normally overridden for
 # each environment below.
-monitor_mode = {{ monitor_mode }}
+monitor_mode = {{ newrelic_monitor_mode }}
 
 # Sets the name of a file to log agent messages to. Useful for
 # debugging any issues with the agent. This is not set by
@@ -52,7 +52,7 @@ monitor_mode = {{ monitor_mode }}
 # write out a log file, it is also possible to say "stderr" and
 # output to standard error output. This would normally result in
 # output appearing in your web server log.
-log_file = {{ log_location }}
+log_file = {{ newrelic_python_logfile }}
 
 # Sets the level of detail of messages sent to the log file, if
 # a log file location has been provided. Possible values, in
@@ -63,7 +63,7 @@ log_file = {{ log_location }}
 # of information very quickly, so it is best not to keep the
 # agent at this level for longer than it takes to reproduce the
 # problem you are experiencing.
-log_level = {{ log_level }}
+log_level = {{ newrelic_loglevel }}
 
 # The Python Agent communicates with the New Relic service using
 # HTTP by default. If you want to communicate via HTTPS to
@@ -72,7 +72,7 @@ log_level = {{ log_level }}
 # perform the encryption involved in SSL communication, but this
 # work is done asynchronously to the threads that process your
 # application code, so it should not impact response times.
-ssl = {{ ssl }}
+ssl = {{ newrelic_ssl }}
 
 # The Python Agent will attempt to connect directly to the New
 # Relic service. If there is an intermediate firewall between
@@ -103,7 +103,7 @@ ignored_params =
 # transactions and sends this to the UI on a periodic basis. The
 # transaction tracer is enabled by default. Set this to "false"
 # to turn it off.
-transaction_tracer.enabled = {{ transaction_trace }}
+transaction_tracer.enabled = {{ newrelic_python_transaction_trace }}
 
 # Threshold in seconds for when to collect a transaction trace.
 # When the response time of a controller action exceeds this


### PR DESCRIPTION
Pretty simple... if the user of the role asks for it this will also render a newrelic python agent configuration as well. 